### PR TITLE
Update flake8 rules to import collection code

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands = {posargs}
 # E123, E125 skipped as they are invalid PEP-8.
 
 show-source = True
-ignore = E123,E125,E402,E501,E741,W503
+ignore = E123,E125,E402,E501,E741,F401,F841,W503
 max-line-length = 160
 builtins = _
 exclude = .git,.tox,tests/unit/compat/


### PR DESCRIPTION
This is only needed to allow us to land the initial sync from
ansible/ansible. This is because we can no longer fix it in
ansible/ansible devel.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>