### PR TITLE
Move requirements to top-level directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible
+paramiko

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-black==19.3b0
+black==19.3b0 ; python_version > '3.5'
 flake8

--- a/tests/integration/network-integration.requirements.txt
+++ b/tests/integration/network-integration.requirements.txt
@@ -1,6 +1,0 @@
-pexpect # for _user test
-scp # for Cisco ios
-selectors2 # for ncclient
-ncclient # for Junos
-jxmlease # for Junos
-xmltodict # for Junos


### PR DESCRIPTION
This will allow us to remove the dependency on ansible-test for
installing python dependencies.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>