### PR TITLE
Update tox.ini for python3 defaults

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,10 @@ envlist = linters
 skipsdist = True
 
 [testenv]
+basepython = python3
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+commands = find {toxinidir} -type f -name "*.py[c|o]" -delete
 
 [testenv:black]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
Now that python2 is EOL, we should move all tox entry points to python3
only.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>