### PR TITLE
To fix older Cisco ASA tests failure

### DIFF
--- a/tests/integration/targets/asa_acl/tasks/cli.yaml
+++ b/tests/integration/targets/asa_acl/tasks/cli.yaml
@@ -8,8 +8,11 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
+- name: Run test case (connection=ansible.netcommon.network_cli)
   include: '{{ test_case_to_run }}'
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/tests/integration/targets/asa_acl/tests/cli/basic.yaml
+++ b/tests/integration/targets/asa_acl/tests/cli/basic.yaml
@@ -1,13 +1,6 @@
 ---
 - debug: msg="START cli/basic.yaml"
 
-- name: setup
-  ignore_errors: true
-  cisco.asa.asa_config:
-    commands:
-      - clear configure access-list ACL-BASIC
-    provider: '{{ cli }}'
-
 - name: Basic ACL
   register: result
   cisco.asa.asa_acl:

--- a/tests/integration/targets/asa_acl/tests/cli/full_name_match.yaml
+++ b/tests/integration/targets/asa_acl/tests/cli/full_name_match.yaml
@@ -1,14 +1,6 @@
 ---
 - debug: msg="START cli/full_name_match.yaml"
 
-- name: setup
-  ignore_errors: true
-  cisco.asa.asa_config:
-    commands:
-      - clear configure access-list ACL-BASIC
-      - clear configure access-list ACL-BASIC2
-    provider: '{{ cli }}'
-
 - name: Basic ACL
   register: result
   cisco.asa.asa_acl:

--- a/tests/integration/targets/asa_acl/tests/cli/insert.yaml
+++ b/tests/integration/targets/asa_acl/tests/cli/insert.yaml
@@ -1,13 +1,6 @@
 ---
 - debug: msg="START cli/insert.yaml"
 
-- name: setup
-  ignore_errors: true
-  cisco.asa.asa_config:
-    commands:
-      - clear configure access-list ACL-INSERT
-    provider: '{{ cli }}'
-
 - name: Create ACL
   register: result
   cisco.asa.asa_acl:

--- a/tests/integration/targets/asa_command/tasks/cli.yaml
+++ b/tests/integration/targets/asa_command/tasks/cli.yaml
@@ -8,8 +8,11 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
+- name: Run test case (connection=ansible.netcommon.network_cli)
   include: '{{ test_case_to_run }}'
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/tests/integration/targets/asa_command/tests/cli/bad_operator.yaml
+++ b/tests/integration/targets/asa_command/tests/cli/bad_operator.yaml
@@ -11,7 +11,6 @@
     wait_for:
 
       - result[0] contains 'Description: Foo'
-    provider: '{{ cli }}'
 
 - assert:
     that:

--- a/tests/integration/targets/asa_command/tests/cli/contains.yaml
+++ b/tests/integration/targets/asa_command/tests/cli/contains.yaml
@@ -10,7 +10,6 @@
     wait_for:
       - result[0] contains 'Cisco Adaptive Security Appliance Software Version'
       - result[1] contains 'Hardware'
-    provider: '{{ cli }}'
 
 - assert:
     that:

--- a/tests/integration/targets/asa_command/tests/cli/invalid.yaml
+++ b/tests/integration/targets/asa_command/tests/cli/invalid.yaml
@@ -7,7 +7,6 @@
   cisco.asa.asa_command:
     commands:
       - show foo
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -20,7 +19,6 @@
     commands:
       - show version
       - show foo
-    provider: '{{ cli }}'
 
 - assert:
     that:

--- a/tests/integration/targets/asa_command/tests/cli/output.yaml
+++ b/tests/integration/targets/asa_command/tests/cli/output.yaml
@@ -6,7 +6,6 @@
   cisco.asa.asa_command:
     commands:
       - show version
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -19,7 +18,6 @@
     commands:
       - show version
       - show interface
-    provider: '{{ cli }}'
 
 - assert:
     that:

--- a/tests/integration/targets/asa_command/tests/cli/timeout.yaml
+++ b/tests/integration/targets/asa_command/tests/cli/timeout.yaml
@@ -9,7 +9,6 @@
       - show version
     wait_for:
       - result[0] contains bad_value_string
-    provider: '{{ cli }}'
 
 - assert:
     that:

--- a/tests/integration/targets/asa_config/tasks/cli.yaml
+++ b/tests/integration/targets/asa_config/tasks/cli.yaml
@@ -8,8 +8,11 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
+- name: Run test case (connection=ansible.netcommon.network_cli)
   include: '{{ test_case_to_run }}'
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/tests/integration/targets/asa_config/tests/cli/backup.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/backup.yaml
@@ -12,7 +12,7 @@
     paths: '{{ role_path }}/backup'
     pattern: '{{ inventory_hostname_short }}_config*'
   register: backup_files
-  delegate_to: localhost
+  connection: local
 
 - name: delete backup files
   file:
@@ -36,7 +36,7 @@
     paths: '{{ role_path }}/backup'
     pattern: '{{ inventory_hostname_short }}_config*'
   register: backup_files
-  delegate_to: localhost
+  connection: local
 
 - assert:
     that:

--- a/tests/integration/targets/asa_config/tests/cli/backup.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/backup.yaml
@@ -6,7 +6,6 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    provider: '{{ cli }}'
 
 - name: collect any backup files
   find:
@@ -26,7 +25,6 @@
   cisco.asa.asa_config:
     src: basic/config.j2
     backup: true
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -48,6 +46,5 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/backup.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/basic.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/basic.yaml
@@ -6,13 +6,11 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    provider: '{{ cli }}'
 
 - name: configure device with config
   register: result
   cisco.asa.asa_config:
     src: basic/config.j2
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -23,7 +21,6 @@
   register: result
   cisco.asa.asa_config:
     src: basic/config.j2
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -34,6 +31,5 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/basic.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/defaults.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/defaults.yaml
@@ -6,14 +6,12 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    provider: '{{ cli }}'
 
 - name: configure device with defaults included
   register: result
   cisco.asa.asa_config:
     src: defaults/config.j2
     defaults: true
-    provider: '{{ cli }}'
 
 - debug: var=result
 
@@ -27,7 +25,6 @@
   cisco.asa.asa_config:
     src: defaults/config.j2
     defaults: true
-    provider: '{{ cli }}'
 
 - debug: var=result
 
@@ -40,6 +37,5 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/defaults.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/force.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/force.yaml
@@ -6,13 +6,11 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    provider: '{{ cli }}'
 
 - name: configure device with config
   register: result
   cisco.asa.asa_config:
     src: basic/config.j2
-    provider: '{{ cli }}'
     match: none
 
 - assert:
@@ -24,7 +22,6 @@
   register: result
   cisco.asa.asa_config:
     src: basic/config.j2
-    provider: '{{ cli }}'
     match: none
 
 - assert:
@@ -36,6 +33,5 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OG-ANSIBLE-TEMPLATE-DEFAULT
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/force.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/more_system.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/more_system.yaml
@@ -1,19 +1,11 @@
 ---
 - debug: msg="START cli/more_system.yaml"
 
-- name: setup
-  ignore_errors: true
-  cisco.asa.asa_config:
-    lines:
-      - clear configure tunnel-group 192.0.2.1
-    provider: '{{ cli }}'
-
 - name: Prepare tunnel-group
   cisco.asa.asa_config:
     before: tunnel-group 192.0.2.1 type ipsec-l2l
     lines:
       - tunnel-group 192.0.2.1 ipsec-attributes
-    provider: '{{ cli }}'
 
 - name: Setup tunnel-group
   cisco.asa.asa_config:
@@ -21,7 +13,6 @@
     lines:
       - ikev1 pre-shared-key abc123
     passwords: true
-    provider: '{{ cli }}'
 
 - name: Test idempotency
   register: result
@@ -30,7 +21,6 @@
     lines:
       - ikev1 pre-shared-key abc123
     passwords: true
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -40,6 +30,5 @@
   cisco.asa.asa_config:
     lines:
       - clear configure tunnel-group 192.0.2.1
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/more_system.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/removal_error.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/removal_error.yaml
@@ -5,22 +5,18 @@
   ignore_errors: true
   cisco.asa.asa_config:
     commands:
-      - clear configure access-list ANSIBLE-DNS
       - no object-group network OGA-GOOGLE-DNS
-    provider: '{{ cli }}'
 
 - name: configure test object-group
   register: result
   cisco.asa.asa_config:
     parents: object-group network OGA-GOOGLE-DNS
     lines: network-object host 8.8.8.8
-    provider: '{{ cli }}'
 
 - name: configure test access-list
   cisco.asa.asa_config:
     lines: access-list ANSIBLE-DNS extended permit udp any object-group OGA-GOOGLE-DNS
       eq domain
-    provider: '{{ cli }}'
 
 - name: try to remove object-group (should fail)
   ignore_errors: true
@@ -28,7 +24,6 @@
   cisco.asa.asa_config:
     commands:
       - no object-group network OGA-GOOGLE-DNS
-    provider: '{{ cli }}'
 
 - name: Last command should fail
   assert:
@@ -40,6 +35,5 @@
     commands:
       - clear configure access-list ANSIBLE-DNS
       - no object-group network OGA-GOOGLE-DNS
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/removal_error.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/sublevel.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel.yaml
@@ -5,7 +5,6 @@
   cisco.asa.asa_config:
     lines:
       - no object-group network OG-ANSIBLE-SUBLEVEL
-    provider: '{{ cli }}'
 
 - name: configure sub level command
   register: result
@@ -14,7 +13,6 @@
       - network-object host 192.168.10.1
     parents:
       - object-group network OG-ANSIBLE-SUBLEVEL
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -29,7 +27,6 @@
       - network-object host 192.168.10.1
     parents:
       - object-group network OG-ANSIBLE-SUBLEVEL
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -39,6 +36,5 @@
   cisco.asa.asa_config:
     lines:
       - no object-group network OG-ANSIBLE-SUBLEVEL
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/sublevel.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/sublevel_block.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel_block.yaml
@@ -6,14 +6,12 @@
   cisco.asa.asa_command:
     commands:
       - show run object-group
-    provider: '{{ cli }}'
 
 - name: setup
   cisco.asa.asa_config:
     lines:
       - no object-group network OG-ANSIBLE
     match: none
-    provider: '{{ cli }}'
 
 - name: configure sub level command using block replace
   register: result
@@ -28,7 +26,6 @@
     replace: block
     after:
       - exit
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -52,7 +49,6 @@
     replace: block
     after:
       - exit
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -62,6 +58,5 @@
   cisco.asa.asa_config:
     lines:
       - no object-group network OG-ANSIBLE
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/sublevel_block.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/sublevel_exact.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel_exact.yaml
@@ -15,7 +15,6 @@
       - no object-group network OG-ANSIBLE-EXACT
     after:
       - exit
-    provider: '{{ cli }}'
 
 - name: configure sub level command using exact match
   register: result
@@ -30,7 +29,6 @@
     after:
       - exit
     match: exact
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -56,7 +54,6 @@
     after:
       - exit
     match: exact
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -66,6 +63,5 @@
   cisco.asa.asa_config:
     lines:
       - no object-group network OG-ANSIBLE-EXACT
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/sublevel_exact.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/sublevel_strict.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel_strict.yaml
@@ -15,7 +15,6 @@
       - no object-group network OG-ANSIBLE-STRICT
     after:
       - exit
-    provider: '{{ cli }}'
 
 - name: configure sub level command using strict match
   register: result
@@ -28,7 +27,6 @@
     parents:
       - object-group network OG-ANSIBLE-STRICT
     match: strict
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -46,7 +44,6 @@
     after:
       - exit
     match: strict
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -62,6 +59,5 @@
   cisco.asa.asa_config:
     lines:
       - no object-group network OG-ANSIBLE-STRICT
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/sublevel_strict.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -10,7 +10,6 @@
       - policy-map p1
       - class c1
     before:
-      - no policy-map p1
       - no class-map c1
     match: none
 

--- a/tests/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -9,8 +9,6 @@
       - match default-inspection-traffic
       - policy-map p1
       - class c1
-    before:
-      - no class-map c1
     match: none
 
 - name: configure sub level command using strict match

--- a/tests/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/sublevel_strict_mul_parents.yaml
@@ -1,6 +1,5 @@
 ---
-- debug: msg="START cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection
-    }}"
+- debug: msg="START cli/sublevel_strict_mul_parents.yaml on connection={{ ansible_connection}}"
 
 - name: setup
   cisco.asa.asa_config:

--- a/tests/integration/targets/asa_config/tests/cli/toplevel.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/toplevel.yaml
@@ -5,14 +5,12 @@
   cisco.asa.asa_config:
     lines:
       - hostname firewall
-    provider: '{{ cli }}'
 
 - name: configure top level command
   register: result
   cisco.asa.asa_config:
     lines:
       - hostname foo
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -24,7 +22,6 @@
   cisco.asa.asa_config:
     lines:
       - hostname foo
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -34,6 +31,5 @@
   cisco.asa.asa_config:
     lines:
       - hostname {{ inventory_hostname_short }}
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/toplevel.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/toplevel_after.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/toplevel_after.yaml
@@ -6,7 +6,6 @@
     lines:
       - snmp-server contact ansible
       - hostname firewall
-    provider: '{{ cli }}'
 
 - name: configure top level command with before
   register: result
@@ -15,7 +14,6 @@
       - hostname foo
     after:
       - snmp-server contact bar
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -30,7 +28,6 @@
       - hostname foo
     after:
       - snmp-server contact foo
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -41,6 +38,5 @@
     lines:
       - no snmp-server contact
       - hostname {{ inventory_hostname_short }}
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/toplevel_after.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/toplevel_before.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/toplevel_before.yaml
@@ -6,7 +6,6 @@
     lines:
       - snmp-server contact ansible
       - hostname firewall
-    provider: '{{ cli }}'
 
 - name: configure top level command with before
   register: result
@@ -15,7 +14,6 @@
       - hostname foo
     before:
       - snmp-server contact bar
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -30,7 +28,6 @@
       - hostname foo
     before:
       - snmp-server contact foo
-    provider: '{{ cli }}'
 
 - assert:
     that:
@@ -41,6 +38,5 @@
     lines:
       - no snmp-server contact
       - hostname {{ inventory_hostname_short }}
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/toplevel_before.yaml"

--- a/tests/integration/targets/asa_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/tests/integration/targets/asa_config/tests/cli/toplevel_nonidempotent.yaml
@@ -4,14 +4,12 @@
 - name: setup
   cisco.asa.asa_config:
     backup: true
-    provider: '{{ cli }}'
 
 - name: configure top level command
   register: result
   cisco.asa.asa_config:
     lines:
       - hostname foo
-    provider: '{{ cli }}'
     match: strict
 
 - assert:
@@ -24,7 +22,6 @@
   cisco.asa.asa_config:
     lines:
       - hostname foo
-    provider: '{{ cli }}'
     match: strict
 
 - assert:
@@ -35,6 +32,5 @@
   cisco.asa.asa_config:
     lines:
       - hostname {{ inventory_hostname_short }}
-    provider: '{{ cli }}'
 
 - debug: msg="END cli/toplevel_nonidempotent.yaml"

--- a/tests/integration/targets/asa_og/tasks/cli.yaml
+++ b/tests/integration/targets/asa_og/tasks/cli.yaml
@@ -9,14 +9,11 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test cases (connection=ansible.netcommon.network_cli)
+- name: Run test case (connection=ansible.netcommon.network_cli)
   include: '{{ test_case_to_run }}'
+  vars:
+    ansible_connection: ansible.netcommon.network_cli
   with_items: '{{ test_items }}'
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: '{{ test_case_to_run }} ansible_connection=local'
-  with_first_found: '{{ test_items }}'
-  loop_control:
-    loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -22,9 +22,6 @@
           - 192.168.0.0 255.255.0.0
           - 172.16.0.0 255.255.0.0
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
-        group_object:
-          - aws_commonservices_eu_ie_pci_prv
-          - aws_commonservices_eu_ie_pci_elb_prv
 
     - name: STAGE 0
       register: result
@@ -35,7 +32,6 @@
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
         description: '{{ description }}'
-        group_object: '{{ group_object }}'
 
     - assert: &id002
         that:
@@ -55,8 +51,6 @@
           - 8.8.9.9
         address:
           - 8.8.8.0 255.255.255.0
-        group_object:
-          - test_network_object_1
 
     - name: STAGE 1
       register: result
@@ -66,7 +60,6 @@
         state: present
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
-        group_object: '{{ group_object }}'
 
     - assert: *id002
 
@@ -91,8 +84,6 @@
           - 8.8.9.9
         address:
           - 8.8.8.0 255.255.255.0
-        group_object:
-          - test_network_object_1
 
     - name: STAGE 2
       register: result
@@ -117,7 +108,6 @@
         state: present
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
-        group_object: '{{ group_object }}'
 
     - assert: *id002
 
@@ -137,9 +127,6 @@
           - 192.168.0.0 255.255.0.0
           - 172.16.0.0 255.255.0.0
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
-        group_object:
-          - aws_commonservices_eu_ie_pci_prv
-          - aws_commonservices_eu_ie_pci_elb_prv
 
     - name: STAGE 3
       register: result
@@ -150,7 +137,6 @@
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
         description: '{{ description }}'
-        group_object: '{{ group_object }}'
 
     - assert: *id002
 
@@ -170,9 +156,6 @@
           - 192.168.0.0 255.255.0.0
           - 172.16.0.0 255.255.0.0
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
-        group_object:
-          - aws_commonservices_eu_ie_pci_prv
-          - aws_commonservices_eu_ie_pci_elb_prv
 
     - name: STAGE 4
       register: result
@@ -183,7 +166,6 @@
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
         description: '{{ description }}'
-        group_object: '{{ group_object }}'
 
     - assert: *id002
 
@@ -201,8 +183,6 @@
           - 10.0.0.0 255.0.0.0
           - 1.0.0.0 255.255.0.0
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
-        group_object:
-          - aws_commonservices_eu_ie_pci_prv
 
     - name: STAGE 5
       register: result
@@ -213,7 +193,6 @@
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
         description: '{{ description }}'
-        group_object: '{{ group_object }}'
 
     - assert: *id002
 
@@ -229,8 +208,6 @@
           - 9.9.9.9
           - 8.8.8.8
         description: th1s_IS-a_D3scrIPt10n_3xaMple-
-        group_object:
-          - test_network_object_1
 
     - name: STAGE 6
       register: result
@@ -241,7 +218,6 @@
         host_ip: '{{ host_ip }}'
         ip_mask: '{{ address }}'
         description: '{{ description }}'
-        group_object: '{{ group_object }}'
 
     - assert: *id002
 

--- a/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
+++ b/tests/integration/targets/asa_og/tests/cli/asa_og.yaml
@@ -502,8 +502,8 @@
       cisco.asa.asa_og: *id021
 
     - assert: *id004
-  always:
 
+  always:
     - name: remove test config if any
       ignore_errors: true
       cisco.asa.asa_config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix older Cisco ASA tests failure, ref: [Run the integration test suite](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_6/6/7d9c1a0a564c266bea159758662c4868f35a8880/check/ansible-test-network-integration-asa-python27/020854c/ara-report/reports/efaf4aa2-3d27-4d01-89ed-5921d8d039f5.html)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
asa_acl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
